### PR TITLE
Don't require a known RHS

### DIFF
--- a/theories/FP.v
+++ b/theories/FP.v
@@ -74,7 +74,7 @@ Instance Canonical_eq_Type : Canonical_eq Type := Canonical_eq_gen _.
 
 Definition FP_Type : Type ≈p Type := {| pr := UR_Type |}.
 
-#[export] Hint Extern 0 (PR Set Set) => exact FP_Type : typeclass_instances. 
+#[export] Hint Extern 0 (PR Set _) => exact FP_Type : typeclass_instances.
 
 (* Axiom SPropProp : path@{_ Type; _} Type Prop SProp.*)
 
@@ -187,15 +187,15 @@ Proof.
   - eapply FP_forall_ur.
 Defined.  
 
-(* #[export] Hint Extern 0 (UR_Type (forall x:_ , _) (forall y:_, _)) => erefine (ur_type (FP_forall _ _ _) _ _ {| ur_type := _|}); cbn in *; intros : typeclass_instances.
+(* #[export] Hint Extern 0 (UR_Type (forall x:_ , _) _) => erefine (ur_type (FP_forall _ _ _) _ _ {| ur_type := _|}); cbn in *; intros : typeclass_instances.
 
-#[export] Hint Extern 100 ((forall x:_ , _) ≃ (forall y:_, _)) => erefine (Equiv_forall _ _ _ _ _ {| ur_type := _|}); cbn in *; intros : typeclass_instances. *)
+#[export] Hint Extern 100 ((forall x:_ , _) ≃ _) => erefine (Equiv_forall _ _ _ _ _ {| ur_type := _|}); cbn in *; intros : typeclass_instances. *)
 
 #[export] Hint Unfold pr : core. 
 Typeclasses Transparent pr.
 #[export] Hint Transparent pr : core. 
 
-(* #[export] Hint Extern 0 (UR_Type (_ -> _) (_ -> _)) =>
+(* #[export] Hint Extern 0 (UR_Type (_ -> _) _) =>
   erefine ((FP_forall _ _ _) _ _ {| ur_type := _|} ); cbn in *; intros : typeclass_instances. *)
 
 #[universes(collapse_sort_variables=no)]
@@ -225,7 +225,7 @@ Proof.
   - cbn; intros. destruct (eB _ _ H). eapply pr_Coh.  
 Defined. 
 
-Hint Extern 0 (UR_Prop (forall x:_ , _) (forall y:_, _)) => unshelve eapply FP_forall_univ_Prop; cbn; intros : typeclass_instances.
+Hint Extern 0 (UR_Prop (forall x:_ , _) _) => unshelve eapply FP_forall_univ_Prop; cbn; intros : typeclass_instances.
 
 (* special cases for arrows *)
 
@@ -233,7 +233,7 @@ Hint Extern 0 (UR_Prop (forall x:_ , _) (forall y:_, _)) => unshelve eapply FP_f
            (eA: A ≈ A') (e' : B ≈ B') :
   (A -> B) ≃ (A' -> B') := Equiv_forall _ _ eA _ _ (fun _ => e').
 
-#[export] Hint Extern 0 ((_ -> _) ≃ (_ -> _)) =>
+#[export] Hint Extern 0 ((_ -> _) ≃ _) =>
   erefine (Equiv_Arrow _ _ _ _ _ _); cbn in *; intros : typeclass_instances. *)
 
 (*

--- a/theories/UR.v
+++ b/theories/UR.v
@@ -106,7 +106,7 @@ Definition PR_Type_gen k (A B:Type) (H:@pr _ _ _ (PR_Type k) A B) : PR k A B :=
 Definition PR_Prop_plain : PR plain Prop SProp := 
   {| pr := PR@{Type _ _ SProp; _ _ _} plain |}.
 
-#[export] Hint Extern 100 (PR plain Prop SProp) => 
+#[export] Hint Extern 100 (PR plain Prop _) =>
   exact PR_Prop_plain : typeclass_instances.
 
 Record UR_Prop (P:Prop) (Q:SProp) :=
@@ -123,7 +123,7 @@ Arguments pr_Coh {_ _} _.
 Definition PR_Prop_univalent : PR univalent Prop SProp := 
   {| pr := UR_Prop |}.
 
-#[export] Hint Extern 100 (PR univalent Prop SProp) => 
+#[export] Hint Extern 100 (PR univalent Prop _) =>
   exact PR_Prop_univalent : typeclass_instances.
 
 #[universes(collapse_sort_variables=no)]
@@ -221,11 +221,11 @@ Definition URForall k A A' (B : A -> Type) (B' : A' -> Type) {HA : PR k A A'}
   :=
   {| pr := fun f g => forall x y (H:x ≈[ k ] y), f x ≈[ k ] g y |}.
 
-#[export] Hint Extern 0 (PR ?k (forall x:?A, _) (forall x:?A', _)) =>
-  unshelve erefine (@URForall_Type k A A' _); intros : typeclass_instances.
+#[export] Hint Extern 0 (PR ?k (forall x:?A, _) _) =>
+  unshelve erefine (@URForall_Type k A _ _); intros : typeclass_instances.
 
-#[export] Hint Extern 1 (PR ?k (forall x:?A, _) (forall x:?A', _)) =>
-  unshelve erefine (@URForall k A A' _ _ _ _); intros : typeclass_instances.
+#[export] Hint Extern 1 (PR ?k (forall x:?A, _) _) =>
+  unshelve erefine (@URForall k A _ _ _ _ _); intros : typeclass_instances.
 
 #[export] Hint Extern 0 =>
   match goal with H : @pr _ _ _

--- a/theories/UR.v
+++ b/theories/UR.v
@@ -56,6 +56,13 @@ Inductive UR_Type A B :=
     Ur_Coh :: UR_Coh A B equiv Ur
   }.
 
+Ltac shelve_non_PR :=
+  lazymatch goal with
+  | [ |- PR _ _ _ ] => idtac
+  | [ |- UR_Type _ _ ] => idtac
+  | [ |- _ ] => shelve
+  end.
+
 Instance PR_Type_univ@{i j} : PR@{Type Type Type Type | j j j} univalent Type@{i} Type@{i} :=
   Build_PR@{Type Type Type Type | j j j} _ _ _ UR_Type@{i i i i i i}.
 
@@ -222,10 +229,10 @@ Definition URForall k A A' (B : A -> Type) (B' : A' -> Type) {HA : PR k A A'}
   {| pr := fun f g => forall x y (H:x ≈[ k ] y), f x ≈[ k ] g y |}.
 
 #[export] Hint Extern 0 (PR ?k (forall x:?A, _) _) =>
-  unshelve erefine (@URForall_Type k A _ _); intros : typeclass_instances.
+  unshelve erefine (@URForall_Type k A _ _); intros; shelve_non_PR : typeclass_instances.
 
 #[export] Hint Extern 1 (PR ?k (forall x:?A, _) _) =>
-  unshelve erefine (@URForall k A _ _ _ _ _); intros : typeclass_instances.
+  unshelve erefine (@URForall k A _ _ _ _ _); intros; shelve_non_PR : typeclass_instances.
 
 #[export] Hint Extern 0 =>
   match goal with H : @pr _ _ _


### PR DESCRIPTION
This is to allow for compatibility with UIP in Prop or SPropThis allows using typeclass resolution to infer the target
translation/equivalence type

cc @tabareau 