### PR TITLE
Don't shelve pr in shelve_non_PR

### DIFF
--- a/theories/UR.v
+++ b/theories/UR.v
@@ -60,6 +60,7 @@ Ltac shelve_non_PR :=
   lazymatch goal with
   | [ |- PR _ _ _ ] => idtac
   | [ |- UR_Type _ _ ] => idtac
+  | [ |- pr _ _ _ ] => idtac
   | [ |- _ ] => shelve
   end.
 


### PR DESCRIPTION
This is to allow for compatibility with UIP in Prop or SProp

cc @tabareau 