### PR TITLE
Generalize tc_hint_for_list to handle specialized lemma

### DIFF
--- a/theories/Ltac2Utils.v
+++ b/theories/Ltac2Utils.v
@@ -3596,7 +3596,10 @@ Ltac2 tc_hint_for_list k (fatal : bool) (warn : bool) (key : constr) (lems : con
   let orig_key := key in
   let key := eta key in
   let lems := List.map eta lems in
+  (* general tactic to solve the goal *)
   let tac goal :=
+     (* [compare_lemmas a lem]: does the type of [lem]'s statement LHS equal [a],
+        the key type adjusted to the goal's sorts? Disambiguates sort variants. *)
      let compare_lemmas lem1 lem2 :=
         let h := type_of_refresh lem2 in
         let h := eval cbn head match in $h in
@@ -3605,29 +3608,43 @@ Ltac2 tc_hint_for_list k (fatal : bool) (warn : bool) (key : constr) (lems : con
         let a := eval cbn head match in $a in
         Constr.equal_nocumul lem1 a
      in
-     let selected_lemma := match goal with
-      | None => List.hd lems
+     (* [selected_lemmas]: all lemmas of [lems] whose LHS type fits the goal's
+        sorts (the full list when no application structure is available, i.e.
+        projection-headed goals); fatal cumulativity diagnostic (or failure)
+        when none does. *)
+     let selected_lemmas := match goal with
+      | None => lems
       | Some goal_lhs =>
         let (_, c_args) := Constr.decompose_app_list_nocast goal_lhs in
         match check_if_cumul_decompose_args key c_args with
           (c_head, c_type, a, l) =>
           let a := adjust_type a goal_lhs in
-          let lems := List.filter (compare_lemmas a) lems in
-          if List.is_empty lems
+          let selected := List.filter (compare_lemmas a) lems in
+          if List.is_empty selected
           then check_if_cumul (c_head, c_type, a, l)
-          else
-            let selected_lemma := List.hd lems in selected_lemma
+          else selected
         end
       end
       in
-        first
-            [
-             unshelve (eapply $selected_lemma); shelve_and_tc ()|
-             pre_tc_hint_hook (); unshelve (eapply $selected_lemma); shelve_and_tc () |
-             forward_apply k selected_lemma goal_lhs |
-             pre_tc_hint_hook () ; forward_apply k selected_lemma goal_lhs
-            ] in
+      (* [try_each tacL ls]: run [tacL] on each lemma with a backtracking point
+         between them, so failures fall through to the next lemma. *)
+      let rec try_each tacL ls :=
+        match ls with
+        | [] => Control.zero Match_failure
+        | l :: tl => Control.plus (fun () => tacL l) (fun _ => try_each tacL tl)
+        end
+      in
+      first
+          [
+            try_each (fun lem => unshelve (eapply $lem); shelve_and_tc ()) (selected_lemmas) |
+            pre_tc_hint_hook (); try_each (fun lem => unshelve (eapply $lem); shelve_and_tc ()) (selected_lemmas) |
+            try_each (fun lem => forward_apply k lem goal_lhs) selected_lemmas |
+            pre_tc_hint_hook () ; try_each (fun lem => forward_apply k lem goal_lhs) selected_lemmas
+          ]
+  in
   let (goal_head, goal_args) := Constr.decompose_app goal_lhs in
+  (* Goal headed by a primitive projection: applies when the key is the
+     matching compatibility constant; no arguments to select a lemma with. *)
   if Constr.is_proj goal_head && Constr.is_const orig_key then
     match Constr.destProj goal_head, Constr.destConstant orig_key with
       | (p,_,_), (const_key, _) =>
@@ -3637,18 +3654,22 @@ Ltac2 tc_hint_for_list k (fatal : bool) (warn : bool) (key : constr) (lems : con
         else Control.zero Match_failure
     end
   else
+  (* Key check: the goal must literally be the key applied to its arguments
+     (compared up to η, so partial applications are accepted too). *)
   match check_appvect key goal_args with
     | Val key_app =>
       let key_app := beta_red key_app in
       if equal_nounivs_upto_eta goal_lhs key_app then
+        (* Reporting mode: fatal lets errors escape; warn prints them and fails
+           quietly; nofatal selects on the bare head (no sort adjustment). *)
         if fatal then
-         tac (Some goal_lhs)
+          tac (Some goal_lhs)
         else if warn then
-         match Control.case_bt (fun () => tac (Some goal_lhs)) with
-         | Val_bt (v, _k) => v
-         | Err_bt err info => printf "Warning: %a\n" (fun () => Message.of_exn_pretty) err; Control.zero_bt err info
-         end
-          else
+          match Control.case_bt (fun () => tac (Some goal_lhs)) with
+          | Val_bt (v, _k) => v
+          | Err_bt err info => printf "Warning: %a\n" (fun () => Message.of_exn_pretty) err; Control.zero_bt err info
+          end
+        else
           tac (Some goal_head)
       else
         Control.zero Match_failure
@@ -3702,38 +3723,6 @@ Ltac tc_hint_for_ur_plain_list_warn k key ur_lems plain_lems goal_lhs :=
 Ltac tc_hint_for_ur_plain_list_nofatal k key ur_lems plain_lems goal_lhs :=
   let tac := ltac2:(k key ur_lems plain_lems goal_lhs |- tc_hint_for_ur_plain_list (Option.get (Ltac1.to_constr k)) false false (Option.get (Ltac1.to_constr key)) (Option.get (Ltac1.to_constr_list ur_lems)) (Option.get (Ltac1.to_constr_list plain_lems)) (Option.get (Ltac1.to_constr goal_lhs))) in
   tac k key ur_lems plain_lems goal_lhs.
-
-Ltac2 array_remove_nth (arr : constr array) (n : int) : constr array :=
-  let len := Array.length arr in
-  Array.init (Int.sub len 1)
-    (fun i => if Int.lt i n then Array.get arr i else Array.get arr (Int.add i 1)).
-
-Ltac2 specialize_arg_matches (key : constr) (goal_lhs : constr) : bool :=
-  let (_h, goal_args) := Constr.decompose_app goal_lhs in
-  match check_appvect key goal_args with
-    | Val key_app =>
-      let key_app := beta_red key_app in
-      equal_nounivs_upto_eta goal_lhs key_app
-    | _ => false
-       end.
-
-Ltac2 tc_hint_for_specialize_arg (key : constr) (lem : constr) (goal_lhs : constr) : unit :=
-  if specialize_arg_matches key goal_lhs
-  then first [ unshelve (eapply $lem); shelve_and_tc ()|
-               pre_tc_hint_hook (); unshelve (eapply $lem); shelve_and_tc () ]
-  else Control.zero Match_failure.
-
-(* Ltac1 bridge, so a [Hint Extern] can call it directly (like [tc_hint_for])
-   without an inline [ltac2:(match! …)].  [arg_index] is taken as [int_or_var] so
-   a literal (e.g. [2]) crosses to Ltac2 as an [int]. *)
-Tactic Notation "tc_hint_for_specialize_arg"
-    constr(key) constr(lem) constr(goal_lhs) :=
-  let tac := ltac2:(key lem goal_lhs |-
-    tc_hint_for_specialize_arg
-      (Option.get (Ltac1.to_constr key))
-      (Option.get (Ltac1.to_constr lem))
-      (Option.get (Ltac1.to_constr goal_lhs))) in
-  tac key lem goal_lhs.
 
 Module Export TCHintNotations.
 

--- a/theories/Ltac2Utils.v
+++ b/theories/Ltac2Utils.v
@@ -3658,8 +3658,8 @@ Ltac2 tc_hint_for_list k (fatal : bool) (warn : bool) (key : constr) (lems : con
 Ltac2 tc_hint_for_ur_plain_list (k:constr) (fatal : bool) (warn : bool) (key : constr) (ur_lems : constr list) (plain_lems : constr list) (goal_lhs : constr) :=
   tc_hint_for_list k fatal warn key (List.append ur_lems plain_lems) goal_lhs.
 
-Ltac2 to_constr_list l := 
-  List.map (fun x => Option.get (Ltac1.to_constr x)) 
+Ltac2 to_constr_list l :=
+  List.map (fun x => Option.get (Ltac1.to_constr x))
   (Option.get (Ltac1.to_list l)).
 
 
@@ -3713,9 +3713,7 @@ Ltac2 specialize_arg_matches (key : constr) (goal_lhs : constr) : bool :=
   match check_appvect key goal_args with
     | Val key_app =>
       let key_app := beta_red key_app in
-      if equal_nounivs_upto_eta goal_lhs key_app then
-        true
-      else false
+      equal_nounivs_upto_eta goal_lhs key_app
     | _ => false
        end.
 
@@ -3728,7 +3726,7 @@ Ltac2 tc_hint_for_specialize_arg (key : constr) (lem : constr) (goal_lhs : const
 (* Ltac1 bridge, so a [Hint Extern] can call it directly (like [tc_hint_for])
    without an inline [ltac2:(match! …)].  [arg_index] is taken as [int_or_var] so
    a literal (e.g. [2]) crosses to Ltac2 as an [int]. *)
-Tactic Notation "tc_hint_for_specialize_arg" 
+Tactic Notation "tc_hint_for_specialize_arg"
     constr(key) constr(lem) constr(goal_lhs) :=
   let tac := ltac2:(key lem goal_lhs |-
     tc_hint_for_specialize_arg
@@ -3749,7 +3747,7 @@ Tactic Notation "tc_hint_for_ur_plain_list_nofatal" constr(k) constr(key) "[" co
   tc_hint_for_ur_plain_list_nofatal k key ur_lems plain_lems goal_lhs.
 End TCHintNotations.
 
-Set Universe Polymorphism. 
+Set Universe Polymorphism.
 Class IsoRegisteredFor@{s1 s2;u1 u2|} {A : Type@{s1;u1}} (a : A) {B : Type@{s2;u2}} (b : B) := {}.
 Hint Mode IsoRegisteredFor + + + + : typeclass_instances.
 #[global] Arguments Build_IsoRegisteredFor {_ _ _ _}.

--- a/theories/StdLib/FP.v
+++ b/theories/StdLib/FP.v
@@ -259,7 +259,7 @@ Qed.
 Definition FP_Sigma : @sigT ≈u @sigT.
 Proof.
   unshelve econstructor.
-  - unshelve erefine (@PRSigma _ _ _ _ _ _ _); intros; shelve_non_PR. eapply H. eapply H0. tc. 
+  - unshelve erefine (@PRSigma _ _ _ _ _ _ _); intros; shelve_non_PR. eapply H. eapply H0. tc.
   - eapply Equiv_Sigma. tc.
   - intros [? ?] [? ?]; cbn in *.
     split; intro e.
@@ -273,9 +273,9 @@ Proof.
       unshelve eapply (snd (Ur_Coh _ _ _)); eauto.
       unfold univalent_transport in *.
       unshelve eapply (snd (Ur_Coh _ _ _)); cbn.
-      2:{ eapply H0; eauto. } 
+      2:{ eapply H0; eauto. }
       unfold univalent_transport.
-      pose proof (snd (Ur_Coh _ _ _) e1). revert x2 e1 e2. 
+      pose proof (snd (Ur_Coh _ _ _) e1). revert x2 e1 e2.
       rewrite H1. intros x2 e1 e2.
       rewrite transport_eq_gen_refl.
       pose (Ur_Coh (H0 x3 (univalent_transport x3) e1)).
@@ -405,7 +405,7 @@ cbn; intros. unshelve econstructor.
 Defined.
 
 #[universes(collapse_sort_variables=no)]
-Definition univ_eq' : 
+Definition univ_eq' :
   (fun A : Prop => @eq A) ≈u @path.
 Proof.
 cbn; intros. unshelve econstructor.
@@ -444,7 +444,7 @@ Arguments SJMeq_refl {A x}.
 Arguments SJMeq {A} x {B} _.
 
 #[universes(collapse_sort_variables=no)]
-Inductive PR_JMeq (A_1 A_2 : Type) (A_R : A_1 -> A_2 -> Type) 
+Inductive PR_JMeq (A_1 A_2 : Type) (A_R : A_1 -> A_2 -> Type)
     (x_1 : A_1) (x_2 : A_2) (x_R : A_R x_1 x_2)
   :
    forall (B_1 B_2 : Type) (B_R : B_1 -> B_2 -> Type)
@@ -456,7 +456,7 @@ Inductive PR_JMeq (A_1 A_2 : Type) (A_R : A_1 -> A_2 -> Type)
 Instance PJMEq (A_1 A_2 : Type) (A_R : A_1 ≈p A_2)
   (x_1 : A_1) (x_2 : A_2) (x_R : x_1 ≈p x_2)
   (B_1 B_2 : Type) (B_R : B_1 ≈p B_2)
-  (y_1 : B_1) (y_2 : B_2) (y_R : y_1 ≈p y_2) : 
+  (y_1 : B_1) (y_2 : B_2) (y_R : y_1 ≈p y_2) :
   PR@{Prop SProp SProp;_ _ _} plain (JMeq x_1 y_1) (SJMeq x_2 y_2)  :=
   {| pr := fun e e' => PR_JMeq _ _ _ _ _ x_R _ _ _ _ _ y_R e e' |}.
 
@@ -469,7 +469,7 @@ Qed.
 Lemma eq_dep_JMeq (A : Type) (x : A) (B : Type) (y : B) :
   {e : A = B & e # x = y} -> JMeq x y.
 Proof.
-  intros [e e']. destruct e. cbn in *. destruct e'. 
+  intros [e e']. destruct e. cbn in *. destruct e'.
   econstructor.
 Qed.
 
@@ -482,7 +482,7 @@ Qed.
 Lemma eq_dep_SJMeq (A : Type) (x : A) (B : Type) (y : B) :
   ({e : A = B & e # x = y}:SProp) -> SJMeq x y.
 Proof.
-  intros [e e']. destruct e. cbn in *. destruct e'. 
+  intros [e e']. destruct e. cbn in *. destruct e'.
   econstructor.
 Qed.
 
@@ -644,7 +644,7 @@ Section SoftwareFoundations.
     split.
     + eapply ap.
     + eapply ap_inv_equiv. apply dec_eq.
-  - intros ? ? ?; reflexivity. 
+  - intros ? ? ?; reflexivity.
   Defined.
 
 End SoftwareFoundations.
@@ -822,7 +822,7 @@ Parameter LF__IndProp__evD_0_iso : iso_statement (ev_0) imported_LF__IndProp__ev
 End Interface'.
 
 Lemma equal_f {X Y} {f g : X -> Y} a : eq f g -> eq (f a) (g a).
-Proof. 
+Proof.
 destruct 1. reflexivity.
 Qed.
 
@@ -1722,7 +1722,7 @@ Proof.
   | [ |- and True True ] => split; apply I
   end.
 Qed.
- 
+
 Parameter imported_LF__AltAuto__matchD_ex2 : import_of (@match_ex2).
 Parameter LF__AltAuto__matchD_ex2_iso : iso_statement (@match_ex2) imported_LF__AltAuto__matchD_ex2.
 #[export] Hint Extern 1 (UR.UR_Type ?goal_lhs _) => tc_hint_for univalent (@match_ex2) LF__AltAuto__matchD_ex2_iso goal_lhs : typeclass_instances ur_typeclass_instances.
@@ -1924,7 +1924,7 @@ Context {A B : Type}.
 Implicit Types (x : A) (f : var -> A) (g : A -> B) (n m : var).
 
 Lemma lift_compR n m f : eq ((+n) >>> ((+m) >>> f)) ((+m+n) >>> f).
-Proof. 
+Proof.
 Admitted.
 
 End LemmasForFun.
@@ -2439,7 +2439,7 @@ Parameter Corelib__Relations__RelationD_Definitions__relation_iso : iso_statemen
 #[export] Hint Extern 1 => progress (unfold Corelib.Relations.Relation_Definitions.relation) : typeclass_instances ur_typeclass_instances.
 
 Parameter imported_Corelib__Classes__Morphisms__Proper : forall y : Type, (y -> y -> SProp) -> y -> SProp.
-Parameter Corelib__Classes__Morphisms__Proper_iso : iso_statement (@Corelib.Classes.Morphisms.Proper) imported_Corelib__Classes__Morphisms__Proper. 
+Parameter Corelib__Classes__Morphisms__Proper_iso : iso_statement (@Corelib.Classes.Morphisms.Proper) imported_Corelib__Classes__Morphisms__Proper.
 #[export] Hint Extern 0 (UR.UR_Type ?goal_lhs _) => tc_hint_for univalent (@Corelib.Classes.Morphisms.Proper) Corelib__Classes__Morphisms__Proper_iso goal_lhs : typeclass_instances ur_typeclass_instances.
 #[export] Hint Extern 0 (UR.pr ?k ?goal_lhs _) => tc_hint_for k (@Corelib.Classes.Morphisms.Proper) Corelib__Classes__Morphisms__Proper_iso goal_lhs : typeclass_instances ur_typeclass_instances.
 
@@ -2505,11 +2505,11 @@ Parameter Corelib__Init__Logic__eq_iso : iso_statement (@Corelib.Init.Logic.eq) 
 #[export] Hint Extern 0 (UR.UR_Type ?goal_lhs _) => tc_hint_for univalent (@Corelib.Init.Logic.eq) Corelib__Init__Logic__eq_iso goal_lhs : typeclass_instances ur_typeclass_instances.
 #[export] Hint Extern 0 (UR.pr ?k ?goal_lhs _) => tc_hint_for k (@Corelib.Init.Logic.eq) Corelib__Init__Logic__eq_iso goal_lhs : typeclass_instances ur_typeclass_instances.
 
-Parameter imported_Corelib__Init__Nat__max : import_of Nat.max. 
+Parameter imported_Corelib__Init__Nat__max : import_of Nat.max.
 Parameter Corelib__Init__Nat__max_iso : iso_statement Nat.max imported_Corelib__Init__Nat__max.
-#[export] Hint Extern 10 => progress (unfold Corelib.Init.Nat.max) : typeclass_instances ur_typeclass_instances. 
+#[export] Hint Extern 10 => progress (unfold Corelib.Init.Nat.max) : typeclass_instances ur_typeclass_instances.
 
-Parameter imported_Corelib__Init__Peano__le : import_of Peano.le. 
+Parameter imported_Corelib__Init__Peano__le : import_of Peano.le.
 Parameter Corelib__Init__Peano__le_iso : iso_statement Peano.le imported_Corelib__Init__Peano__le.
 #[export] Hint Extern 0 (UR.UR_Type ?goal_lhs _) => tc_hint_for univalent (@Corelib.Init.Peano.le) Corelib__Init__Peano__le_iso goal_lhs : typeclass_instances ur_typeclass_instances.
 #[export] Hint Extern 0 (UR.pr ?k ?goal_lhs _) => tc_hint_for k (@Corelib.Init.Peano.le) Corelib__Init__Peano__le_iso goal_lhs : typeclass_instances ur_typeclass_instances.
@@ -2544,7 +2544,7 @@ Parameter Corelib__Numbers__BinNums__positive_iso : iso_statement (@Corelib.Numb
 #[export] Hint Extern 0 (UR.UR_Type ?goal_lhs _) => tc_hint_for univalent (@Corelib.Numbers.BinNums.positive) Corelib__Numbers__BinNums__positive_iso goal_lhs : typeclass_instances ur_typeclass_instances.
 #[export] Hint Extern 0 (UR.pr ?k ?goal_lhs _) => tc_hint_for k (@Corelib.Numbers.BinNums.positive) Corelib__Numbers__BinNums__positive_iso goal_lhs : typeclass_instances ur_typeclass_instances.
 
-From Corelib Require Import Floats.SpecFloat. 
+From Corelib Require Import Floats.SpecFloat.
 
 Parameter imported_Corelib__Floats__SpecFloat__iterD_pos : import_of (@Corelib.Floats.SpecFloat.iter_pos).
 Parameter Corelib__Floats__SpecFloat__iterD_pos_iso : iso_statement (@Corelib.Floats.SpecFloat.iter_pos) imported_Corelib__Floats__SpecFloat__iterD_pos.
@@ -2578,7 +2578,7 @@ Parameter Stdlib__PArith__BinPos__Pos__toD_pos_iter_iso : iso_statement (@Stdlib
 Lemma iter_pos_nat :
   forall A f (p : positive) (x : A),
   eq (iter_pos A f x p) (iter_nat f (Pos.to_nat p) x).
-Admitted. 
+Admitted.
 
 Parameter imported_Flocq__Core__Zaux__iterD_posD_nat : import_of (@iter_pos_nat).
 Parameter Flocq__Core__Zaux__iterD_posD_nat_iso : iso_statement (@iter_pos_nat) imported_Flocq__Core__Zaux__iterD_posD_nat.
@@ -2736,7 +2736,7 @@ End Interface35.
 (*
 Module Type Interface36 (Import args : Args).
 
-From Stdlib Require Import Formula. 
+From Stdlib Require Import Formula.
 Parameter imported_Cdcl__Formula__IntMap__ptrie : Type -> Type -> Type.
 Parameter Cdcl__Formula__IntMap__ptrie_iso : (@UR.pr _ _ _
      (@UR.URArrow@{Type Type Type Type Type Type ; _ _ _ _ _ _ _ _ _} UR.univalent Type Type (forall _ : Type, Type) (forall _ : Type, Type) (UR.PR_Type@{Type Type Type ; _ _ _ _} UR.univalent)
@@ -2907,7 +2907,7 @@ Parameter SimpleIO__IOD_Monad__IO__bind_iso : (@UR.pr _ _ _
             @UR.URArrow@{Type Type Type Type Type Type ; _ _ _ _ _ _ _ _ _} UR.univalent (IO x) (imported_SimpleIO__IOD_Monad__IO y) (forall _ : forall _ : x, IO x0, IO x0)
               (forall _ : forall _ : y, imported_SimpleIO__IOD_Monad__IO y0, imported_SimpleIO__IOD_Monad__IO y0)
               (@UR.PR_Type_univ_univ@{Type Type Type ; _ _ _ _} (IO x) (imported_SimpleIO__IOD_Monad__IO y) (@SimpleIO__IOD_Monad__IO_iso x y H))
-              (@UR.URArrow@{Type Type Type Type Type Type ; _ _ _ _ _ _ _ _ _} UR.univalent (forall _ : x, IO x0) (forall _ : y, imported_SimpleIO__IOD_Monad__IO y0) 
+              (@UR.URArrow@{Type Type Type Type Type Type ; _ _ _ _ _ _ _ _ _} UR.univalent (forall _ : x, IO x0) (forall _ : y, imported_SimpleIO__IOD_Monad__IO y0)
                  (IO x0) (imported_SimpleIO__IOD_Monad__IO y0)
                  (@UR.URArrow@{Type Type Type Type Type Type ; _ _ _ _ _ _ _ _ _} UR.univalent x y (IO x0) (imported_SimpleIO__IOD_Monad__IO y0)
                     (UR.PR_Type_gen@{Type Type Type ; _ _ _ _} UR.univalent x y H)
@@ -2952,7 +2952,7 @@ Parameter Corelib__Init__Logic__and_iso : (@UR.pr _ _ _
      and imported_Corelib__Init__Logic__and).
 #[export] Hint Extern 0 (UR.UR_Type ?goal_lhs _) => tc_hint_for univalent (@Corelib.Init.Logic.and) Corelib__Init__Logic__and_iso goal_lhs : typeclass_instances ur_typeclass_instances.
 #[export] Hint Extern 0 (UR.pr ?k ?goal_lhs _) => tc_hint_for k (@Corelib.Init.Logic.and) Corelib__Init__Logic__and_iso goal_lhs : typeclass_instances ur_typeclass_instances.
- 
+
 Parameter imported_Corelib__Init__Logic__ex : forall y : Type, (y -> SProp) -> SProp.
 Parameter Corelib__Init__Logic__ex_iso : (@UR.pr _ _ _
      (@UR.URForall@{Type Type Type Type Type Type ; _ _ _ _ _ _ _ _ _} UR.univalent Type Type (fun x : Type => forall _ : forall _ : x, Prop, Prop)
@@ -3037,7 +3037,7 @@ Parameter LF__Basics__bool_iso : (@UR.pr _ _ _ (UR.PR_Type@{Type Type Type ; _ _
 #[export] Hint Extern 0 (UR.UR_Type ?goal_lhs _) => tc_hint_for univalent (@bool) LF__Basics__bool_iso goal_lhs : typeclass_instances ur_typeclass_instances.
 #[export] Hint Extern 0 (UR.pr ?k ?goal_lhs _) => tc_hint_for k (@bool) LF__Basics__bool_iso goal_lhs : typeclass_instances ur_typeclass_instances.
 
-Inductive Toy : Type := 
+Inductive Toy : Type :=
   | con1 : bool -> Toy
   | con2 : nat -> Toy -> Toy.
 
@@ -3051,7 +3051,7 @@ Theorem Toy_correct : exists f g,
     (forall b : bool, P (f b)) ->
     (forall (n : nat) (t : Toy), P t -> P (g n t)) ->
     forall t : Toy, P t.
-Admitted. 
+Admitted.
 
 Parameter imported_LF__IndPrinciples__ToyD_correct : import_of (@Toy_correct).
 Parameter LF__IndPrinciples__ToyD_correct_iso : iso_statement (@Toy_correct) imported_LF__IndPrinciples__ToyD_correct.
@@ -3217,7 +3217,7 @@ Parameter Corelib__Init__Specif__exist_iso : iso_statement
 #[export] Hint Extern 0 (UR.UR_Type ?goal_lhs _) => tc_hint_for univalent (fun A P => @exist A P) Corelib__Init__Specif__exist_iso goal_lhs : typeclass_instances ur_typeclass_instances.
 #[export] Hint Extern 0 (UR.pr ?k ?goal_lhs _) => tc_hint_for k (fun A P => @Corelib.Init.Specif.exist A P) Corelib__Init__Specif__exist_iso goal_lhs : typeclass_instances ur_typeclass_instances.
 
-Parameter imported_Corelib__Init__Specif__proj1D_sig : import_of (@proj1_sig). 
+Parameter imported_Corelib__Init__Specif__proj1D_sig : import_of (@proj1_sig).
 Parameter Corelib__Init__Specif__proj1D_sig_iso : iso_statement (@proj1_sig) imported_Corelib__Init__Specif__proj1D_sig.
 #[export] Hint Extern 0 (UR.UR_Type ?goal_lhs _) => tc_hint_for univalent (@Corelib.Init.Specif.proj1_sig) Corelib__Init__Specif__proj1D_sig_iso goal_lhs : typeclass_instances ur_typeclass_instances.
 #[export] Hint Extern 0 (UR.pr ?k ?goal_lhs _) => tc_hint_for k (@Corelib.Init.Specif.proj1_sig) Corelib__Init__Specif__proj1D_sig_iso goal_lhs : typeclass_instances ur_typeclass_instances.
@@ -3491,23 +3491,23 @@ Parameter Corelib__Init__Logic__eq_iso : iso_statement (fun (A : Type) (x x0 : A
 Parameter imported_Corelib__Init__Logic__eq_Prop : forall y : SProp, y -> y -> SProp.
 Parameter Corelib__Init__Logic__eq_iso_Prop : iso_statement  (fun (A : Prop) (x x0 : A) => @Corelib.Init.Logic.eq A x x0) imported_Corelib__Init__Logic__eq_Prop.
 #[export] Hint Extern 0 (UR.UR_Type ?goal_lhs _) => tc_hint_for_ur_plain_hlist  univalent(@Corelib.Init.Logic.eq) [(* ((fun A : Prop => @Corelib.Init.Logic.eq A)) *) Corelib__Init__Logic__eq_iso_Prop; Corelib__Init__Logic__eq_iso] goal_lhs : typeclass_instances ur_typeclass_instances.
-#[export] Hint Extern 0 (UR.pr ?k ?goal_lhs _) => 
+#[export] Hint Extern 0 (UR.pr ?k ?goal_lhs _) =>
   tc_hint_for_ur_plain_list k (@Corelib.Init.Logic.eq) [@Corelib__Init__Logic__eq_iso_Prop; @Corelib__Init__Logic__eq_iso] [] goal_lhs : typeclass_instances ur_typeclass_instances.
 
 Parameter imported_Corelib__ssr__ssrunder__UnderD_rel__UnderD_rel : forall y : Type, (y -> y -> SProp) -> y -> y -> SProp.
 Parameter Corelib__ssr__ssrunder__UnderD_rel__UnderD_rel_iso : iso_statement (@ssrunder.Under_rel.Under_rel) imported_Corelib__ssr__ssrunder__UnderD_rel__UnderD_rel.
-#[export] Hint Extern 0 (UR.UR_Type ?goal_lhs _) => 
+#[export] Hint Extern 0 (UR.UR_Type ?goal_lhs _) =>
   tc_hint_for_ur_plain_hlist univalent (@Corelib.ssr.ssrunder.Under_rel.Under_rel) [Corelib__ssr__ssrunder__UnderD_rel__UnderD_rel_iso] goal_lhs : typeclass_instances ur_typeclass_instances.
 
 #[export] Hint Extern 0 (UR.pr ?k ?goal_lhs _) =>
-  tc_hint_for_ur_plain_list k (@Corelib.ssr.ssrunder.Under_rel.Under_rel) 
-    [@Corelib__ssr__ssrunder__UnderD_rel__UnderD_rel_iso] 
+  tc_hint_for_ur_plain_list k (@Corelib.ssr.ssrunder.Under_rel.Under_rel)
+    [@Corelib__ssr__ssrunder__UnderD_rel__UnderD_rel_iso]
     [] goal_lhs: typeclass_instances ur_typeclass_instances.
 
 #[universes(polymorphic,collapse_sort_variables=no)]
 Goal {B :_ & PR univalent (forall (A : Type) (eqA : A -> A -> Prop),
 eq (ssrunder.Under_rel.Under_rel A eqA) eqA) B}.
-Proof. 
+Proof.
   eexists. tc.
 Abort.
 
@@ -3521,7 +3521,7 @@ End Interface42.
 
 Module Type Interface43 (Import args : Args).
 
-Require Import List. 
+Require Import List.
 
 Parameter imported_Corelib__Init__Datatypes__list : import_of list.
 Parameter Corelib__Init__Datatypes__list_iso : iso_statement
@@ -3935,6 +3935,23 @@ Module Interface46.
 
   #[export] Hint Extern 1 (UR.pr plain ?g _) => tc_hint_for_ur_plain_list plain (@eval_bf) [eval_bf_iso;eval_bf_iso_isProp] [] g : typeclass_instances ur_typeclass_instances.
 
+  (* Test new definition of [compute_triple] with evar created without unneed dependency *)
+  Goal forall (A A' : Type) (AR : A ≈p A')
+        (ea  : forall k:kind, A  -> rtyp k)
+        (ea' : forall k' : imported_kind, A' -> imported_rtyp k')
+        (eaR : ea ≈p ea'),
+      ea ≈p ea'.
+  Proof.
+    intros.
+    (* The old definition of [compute_triple] created the [PR] instance evar
+       while elaborating [t'']'s type, i.e. with [t' := ?x : ?B] already in
+       its context, so its [tc] call died on the occurs-check: *)
+    Fail ltac2:(unshelve refine '(let t' := _ in let t'' : &ea ≈[plain] @t' := _ in _); shelve_non_PR_multi ();
+                Control.extend [ (fun _ => tc ()) ; (fun _ => unfold &t'; tc ()) ; (fun _ => Std.rename [(@t', @f); (@t'', @g)]) ] (fun _ => ()) []).
+    ltac2:(compute_triple 'plain 'ea @f @g).
+    exact eaR.
+  Abort.
+
   (* If a term of type [imported_rtyp isProp] is expected, [eval_bf] should be translated as usual *)
   Goal forall (A A' : Type) (AR : A ≈p A')
         (ea  : forall k, A  -> rtyp k)
@@ -3946,23 +3963,6 @@ Module Interface46.
     intros. eexists. tc.
   Qed.
 
-  #[universes(polymorphic,collapse_sort_variables=no)]
-  Goal forall (A A' : Type) (AR : A ≈p A')
-        (ea  : forall k, A  -> rtyp k)
-        (ea' : forall k' : imported_kind, A' -> imported_rtyp k')
-        (eaR : ea ≈p ea')
-        (f : A) (f' : A') (fR : f ≈p f'),
-      { B : _ & (hold isProp (@eval_bf A ea isProp f)) ≈p B }.
-  Proof.
-    intros.
-unshelve refine (let f : {B : _ & PR plain
-   (forall (k : kind) (_ : A), rtyp k) 
-   B} := _ in _).
-    eexists. tc.
-    (* this failure is weird *)
-    Fail unshelve refine (let t' := _ : _ in let t'' : @pr plain _ _ _ ea t' := _ in _); shelve_non_PR.
-  Abort. 
-
   (* However, as a type it fail as the type of [imported_eval_bf] is [imported_rtype imported_isProp]
      which does not compute since [imported_rtype] is abstract *)
   #[universes(polymorphic,collapse_sort_variables=no)]
@@ -3971,11 +3971,11 @@ unshelve refine (let f : {B : _ & PR plain
         (ea' : _)
         (eaR : ea ≈p ea')
         (f : A) (f' : A') (fR : f ≈p f'),
-        { B : _ & (@eval_bf A ea isProp f) ≈p B }. 
+        { B : _ & (@eval_bf A ea isProp f) ≈p B }.
   Proof.
-    intros. 
-    eexists. 
-    Fail tc.  
+    intros.
+    eexists.
+    Fail tc.
   Abort.
 
   #[export] Hint Extern 1 (UR.pr ?k ?g _) => tc_hint_for_specialize_arg (@eval_bf) eval_bf_iso_isProp g : typeclass_instances ur_typeclass_instances.

--- a/theories/StdLib/FP.v
+++ b/theories/StdLib/FP.v
@@ -3933,8 +3933,6 @@ Module Interface46.
   Parameter imported_eval_bf_isProp : plain_import_of (fun A ea f => @eval_bf A ea isProp f).
   Parameter eval_bf_iso_isProp : plain_iso_statement (fun A ea f => @eval_bf A ea isProp f) imported_eval_bf_isProp.
 
-  #[export] Hint Extern 1 (UR.pr plain ?g _) => tc_hint_for_ur_plain_list plain (@eval_bf) [eval_bf_iso;eval_bf_iso_isProp] [] g : typeclass_instances ur_typeclass_instances.
-
   (* Test new definition of [compute_triple] with evar created without unneed dependency *)
   Goal forall (A A' : Type) (AR : A ≈p A')
         (ea  : forall k:kind, A  -> rtyp k)
@@ -3952,55 +3950,133 @@ Module Interface46.
     exact eaR.
   Abort.
 
-  (* If a term of type [imported_rtyp isProp] is expected, [eval_bf] should be translated as usual *)
-  Goal forall (A A' : Type) (AR : A ≈p A')
+  (* With only the generic [eval_bf_iso] registered, [eval_bf] can be
+     translated in term position, but not in sort position. *)
+  Section EvalBfOnly.
+
+    #[local] Hint Extern 1 (UR.pr plain ?g _) => tc_hint_for_ur_plain_list plain (@eval_bf) [eval_bf_iso] [] g : typeclass_instances ur_typeclass_instances.
+
+    (* If a term of type [imported_rtyp isProp] is expected, [eval_bf] is
+       translated as usual: the generic iso suffices. *)
+    Goal forall (A A' : Type) (AR : A ≈p A')
+          (ea  : forall k, A  -> rtyp k)
+          (ea' : forall k' : imported_kind, A' -> imported_rtyp k')
+          (eaR : ea ≈p ea')
+          (f : A) (f' : A') (fR : f ≈p f'),
+        { B : _ & (hold isProp (@eval_bf A ea isProp f)) ≈p B }.
+    Proof.
+      intros. eexists. tc.
+    Qed.
+
+    (* However, in sort position it fails: [eval_bf_iso] only relates the terms
+       at the abstract instance [rtyp_iso isProp _ _] — the imported result type
+       [imported_rtyp imported_isProp] does not compute to a sort since
+       [imported_rtyp] is abstract — while the goal needs the sort instance
+       [PR_Type plain]. *)
+    #[universes(polymorphic,collapse_sort_variables=no)]
+    Goal forall (A A' : Type) (AR : A ≈p A')
+          (ea  : forall k, A  -> rtyp k)
+          (ea' : _)
+          (eaR : ea ≈p ea')
+          (f : A) (f' : A') (fR : f ≈p f'),
+          { B : _ & (@eval_bf A ea isProp f) ≈p B }.
+    Proof.
+      intros.
+      eexists.
+      Fail tc.
+    Abort.
+
+  End EvalBfOnly.
+
+  Section EvalBfPropOnly.
+
+  #[local] Hint Extern 1 (UR.pr plain ?g _) => tc_hint_for_ur_plain_list plain (@eval_bf) [eval_bf_iso_isProp] [] g : typeclass_instances ur_typeclass_instances.
+
+    (* If a term of type [imported_rtyp isProp] is expected, [eval_bf] is
+       translated as usual: the generic iso suffices. *)
+    Goal forall (A A' : Type) (AR : A ≈p A')
         (ea  : forall k, A  -> rtyp k)
         (ea' : forall k' : imported_kind, A' -> imported_rtyp k')
         (eaR : ea ≈p ea')
         (f : A) (f' : A') (fR : f ≈p f'),
-      { B : _ & (hold isProp (@eval_bf A ea isProp f)) ≈p B }.
-  Proof.
-    intros. eexists. tc.
-  Qed.
+        { B : _ & (hold isProp (@eval_bf A ea isProp f)) ≈p B }.
+    Proof.
+      intros. eexists. Fail tc.
+    Abort.
 
-  (* However, as a type it fail as the type of [imported_eval_bf] is [imported_rtype imported_isProp]
-     which does not compute since [imported_rtype] is abstract *)
-  #[universes(polymorphic,collapse_sort_variables=no)]
-  Goal forall (A A' : Type) (AR : A ≈p A')
+    (* And the sort-position example now succeeds via the specialized iso in the
+      hint list — no separate hint mechanism needed. *)
+    Goal forall (A A' : Type) (AR : A ≈p A')
         (ea  : forall k, A  -> rtyp k)
-        (ea' : _)
+        (ea' : forall k' : imported_kind, A' -> imported_rtyp k')
         (eaR : ea ≈p ea')
         (f : A) (f' : A') (fR : f ≈p f'),
         { B : _ & (@eval_bf A ea isProp f) ≈p B }.
-  Proof.
-    intros.
-    eexists.
-    Fail tc.
-  Abort.
+    Proof.
+      intros. eexists. tc.
+    Qed.
 
-  #[export] Hint Extern 1 (UR.pr ?k ?g _) => tc_hint_for_specialize_arg (@eval_bf) eval_bf_iso_isProp g : typeclass_instances ur_typeclass_instances.
+  End EvalBfPropOnly.
 
-  (* The usual example still works *)
-  Goal forall (A A' : Type) (AR : A ≈p A')
-      (ea  : forall k, A  -> rtyp k)
-      (ea' : forall k' : imported_kind, A' -> imported_rtyp k')
-      (eaR : ea ≈p ea')
-      (f : A) (f' : A') (fR : f ≈p f'),
-      { B : _ & (hold isProp (@eval_bf A ea isProp f)) ≈p B }.
-  Proof.
-    intros. eexists. tc.
-  Qed.
+  Section EvalBfAndProp.
 
-  (* It now succeds in a sort position due to new hint  *)
-  Goal forall (A A' : Type) (AR : A ≈p A')
-      (ea  : forall k, A  -> rtyp k)
-      (ea' : forall k' : imported_kind, A' -> imported_rtyp k')
-      (eaR : ea ≈p ea')
-      (f : A) (f' : A') (fR : f ≈p f'),
-      { B : _ & (@eval_bf A ea isProp f) ≈p B }.
-  Proof.
-    intros. eexists. tc.
-  Qed.
+    #[local] Hint Extern 1 (UR.pr plain ?g _) => tc_hint_for_ur_plain_list plain (@eval_bf) [eval_bf_iso; eval_bf_iso_isProp] [] g : typeclass_instances ur_typeclass_instances.
+
+      (* If a term of type [imported_rtyp isProp] is expected, [eval_bf] is
+        translated as usual: the generic iso suffices. *)
+      Goal forall (A A' : Type) (AR : A ≈p A')
+          (ea  : forall k, A  -> rtyp k)
+          (ea' : forall k' : imported_kind, A' -> imported_rtyp k')
+          (eaR : ea ≈p ea')
+          (f : A) (f' : A') (fR : f ≈p f'),
+          { B : _ & (hold isProp (@eval_bf A ea isProp f)) ≈p B }.
+      Proof.
+        intros. eexists. tc.
+      Qed.
+
+      (* And the sort-position example now succeeds via the specialized iso in the
+        hint list — no separate hint mechanism needed. *)
+      Goal forall (A A' : Type) (AR : A ≈p A')
+          (ea  : forall k, A  -> rtyp k)
+          (ea' : forall k' : imported_kind, A' -> imported_rtyp k')
+          (eaR : ea ≈p ea')
+          (f : A) (f' : A') (fR : f ≈p f'),
+          { B : _ & (@eval_bf A ea isProp f) ≈p B }.
+      Proof.
+        intros. eexists. tc.
+      Qed.
+
+  End EvalBfAndProp.
+
+  Section EvalBfAndPropRev.
+
+    #[local] Hint Extern 1 (UR.pr plain ?g _) => tc_hint_for_ur_plain_list plain (@eval_bf) [eval_bf_iso_isProp; eval_bf_iso] [] g : typeclass_instances ur_typeclass_instances.
+
+      (* If a term of type [imported_rtyp isProp] is expected, [eval_bf] is
+        translated as usual: the generic iso suffices. *)
+      Goal forall (A A' : Type) (AR : A ≈p A')
+          (ea  : forall k, A  -> rtyp k)
+          (ea' : forall k' : imported_kind, A' -> imported_rtyp k')
+          (eaR : ea ≈p ea')
+          (f : A) (f' : A') (fR : f ≈p f'),
+          { B : _ & (hold isProp (@eval_bf A ea isProp f)) ≈p B }.
+      Proof.
+        intros. eexists. tc.
+      Qed.
+
+      (* And the sort-position example now succeeds via the specialized iso in the
+        hint list — no separate hint mechanism needed. *)
+      Goal forall (A A' : Type) (AR : A ≈p A')
+          (ea  : forall k, A  -> rtyp k)
+          (ea' : forall k' : imported_kind, A' -> imported_rtyp k')
+          (eaR : ea ≈p ea')
+          (f : A) (f' : A') (fR : f ≈p f'),
+          { B : _ & (@eval_bf A ea isProp f) ≈p B }.
+      Proof.
+        intros. eexists. tc.
+      Qed.
+
+  End EvalBfAndPropRev.
 
 End Interface46.
 

--- a/theories/UR.v
+++ b/theories/UR.v
@@ -338,7 +338,7 @@ Ltac2 apply_var_tac c :=
       in let apply_h () := match! reverse goal with
           | [ h : @pr ?k _ _ _ ?c _ |- _] => apply_h_goal k h c
           | [ h : @PR ?k ?c _ |- _] => apply_h_goal k h c
-          end 
+          end
       in
       first [apply_h () |
              erefineb (PR_Type_univ_univ _); apply_h ()|
@@ -612,7 +612,8 @@ Ltac2 Set compute_triple := fun (t:constr) (f:ident) (g:ident) =>
 *)
 #[global]
 Ltac2 Set compute_triple := fun (k:constr) (t:constr) (f:ident) (g:ident) =>
-  unshelve refine '(let t' := _ in let t'' : $t ≈[$k] @t' := _ in _); shelve_non_PR_multi ();
+  let inst := Constr.open_pretype_no_tc preterm:(_ :> PR $k _ _) in
+  unshelve refine '(let t' := _ in let t'' : @pr $k _ _ $inst $t t' := _ in _); shelve_non_PR_multi ();
    Control.extend [ (fun _ => tc ()) ; (fun _ => unfold &t'; tc () ) ; (fun _ => Std.rename [(@t',f);(@t'',g)]) ] (fun _ => ()) [].
 
 


### PR DESCRIPTION
Add a typeclass hint method to translate constant to specialized version of it to deal with converitbility issue.
C.f. the new exampler in FP.v

I am not sure this the best method to do as it seems a bit ad-hoc but it works, 
and I don't see how to modify tc_hint_for_list without rewritting it completely since the choice of lemma is done very different.